### PR TITLE
added Format's link to google doc submission form on the Idea tab

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -18,6 +18,13 @@ class FrontEndParty < Sinatra::Base
     end
   end
 
+  def submission_form_url
+    # joe's
+    "https://docs.google.com/a/joeellis.la/spreadsheet/viewform?formkey=dC1SQlBHdU5yS2xKODR0bjR5QTFENHc6MQ"
+    # shwery's
+    # "https://docs.google.com/forms/d/1xz8g9apBkmW5g8v-E8nmD_Hjriv3e31urZc2zU4VWxY/viewform"
+  end
+
   get "/" do
     erb :index, :locals => {:next_meeting => next_meeting("October 24th 2013").strftime("%B %e, %Y") }
   end

--- a/views/index.erb
+++ b/views/index.erb
@@ -42,6 +42,10 @@
 					<p>
 						If this sounds like you, then come <a href="http://www.meetup.com/FrontEndParty">join us</a> at the next FrontEndParty and throw your ideas into the mix.  We’ll host three 15 minute presentations from developers and designers around New Orleans.  Plus it’s free!
 					</p>
+
+					<p>
+						Want to present at #FrontEndParty? <a href="<%= submission_form_url %>" target="_blank">Submit your talk idea</a> and we'll be in touch.
+					</p>
 				</div>
 
 				<div class="content-part format-part" data-content="format">
@@ -51,7 +55,7 @@
 							<div class="format-description">
 								<h5>Three 15 minute presentations</h5>
 								<p>
-									Each meeting will start with three lightning talks about front-end development and design, which should range from 5 to 15 minutes each.  Want to talk about Backbone.js?  Looking for design critiques from experienced professionals?  We want to see you present!  <a href="https://docs.google.com/a/joeellis.la/spreadsheet/viewform?formkey=dC1SQlBHdU5yS2xKODR0bjR5QTFENHc6MQ">Apply here to talk!</a>
+									Each meeting will start with three lightning talks about front-end development and design, which should range from 5 to 15 minutes each.  Want to talk about Backbone.js?  Got some tips on Angular? Opinionated on OOCSS? Looking for design critiques from experienced professionals?  We want to see you present!  <a href="<%= submission_form_url %>" target="_blank">Apply here to talk!</a>
 								</p>
 							</div>
 						</li>


### PR DESCRIPTION
Alls I did was put the same Google Doc link on "The Idea" tab (it's already on "The Format" tab). We should probably make something more noticeably design-y to attract presenters – although I'm finding myself with a bit of creativity block when I look at this page.
